### PR TITLE
add SHA to sidebar. Includes auto-generated link to GH repo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ build:
   env:
     - CGO_ENABLED=0
   ldflags:
-    - -s -w -X github.com/filebrowser/filebrowser/v2/version.Version={{ .Version }} -X github.com/filebrowser/filebrowser/v2/version.CommitSHA={{ .ShortCommit }}
+    - -s -w -X github.com/filebrowser/filebrowser/v2/version.Version={{ .Version }} -X github.com/filebrowser/filebrowser/v2/version.CommitSHA={{ .ShortCommit }} -X github.com/filebrowser/filebrowser/v2/version.GitURL={{ .GitURL }}
   main: main.go
   binary: filebrowser
   goos:

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ VERSION ?= $(shell git describe --tags --always --match=v* 2> /dev/null || \
 			cat $(CURDIR)/.version 2> /dev/null || echo v0)
 VERSION_HASH = 	$(shell git rev-parse HEAD)
 BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+GIT_URL = $(shell git config --get remote.origin.url)
 
-LDFLAGS += -X "$(MODULE)/varsion.Version=$(VERSION)" -X "$(MODULE)/varsion.CommitSHA=$(VERSION_HASH)"
+LDFLAGS += -X "$(MODULE)/version.Version=$(VERSION)" -X "$(MODULE)/version.CommitSHA=$(VERSION_HASH)" -X "$(MODULE)/version.GitURL=$(GIT_URL)"
 
 # tools
 $(BIN):

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -48,6 +48,12 @@
         <a v-else rel="noopener noreferrer" target="_blank" href="https://github.com/filebrowser/filebrowser">File Browser</a>
         <span> {{ version }}</span>
       </span>
+      <span>
+        Commit SHA: 
+        <a rel="noopener noreferrer" target="_blank" :href="gitURL+'/commit/'+commitSHA">
+          <span style="width:3.7em;overflow:hidden;display:inline-block;white-space:nowrap;vertical-align:bottom;">{{ commitSHA }}</span>
+        </a>
+      </span>
       <span><a @click="help">{{ $t('sidebar.help') }}</a></span>
     </p>
   </nav>
@@ -56,7 +62,7 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import * as auth from '@/utils/auth'
-import { version, signup, disableExternal, noAuth, authMethod } from '@/utils/constants'
+import { version, signup, disableExternal, noAuth, authMethod, commitSHA, gitURL } from '@/utils/constants'
 
 export default {
   name: 'sidebar',
@@ -70,7 +76,9 @@ export default {
     version: () => version,
     disableExternal: () => disableExternal,
     noAuth: () => noAuth,
-    authMethod: () => authMethod
+    authMethod: () => authMethod,
+    commitSHA: () => commitSHA,
+    gitURL: () => gitURL
   },
   methods: {
     help () {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -14,6 +14,8 @@ const theme = window.FileBrowser.Theme
 const enableThumbs = window.FileBrowser.EnableThumbs
 const resizePreview = window.FileBrowser.ResizePreview
 const enableExec = window.FileBrowser.EnableExec
+const commitSHA = window.FileBrowser.CommitSHA
+const gitURL = window.FileBrowser.GitURL
 
 export {
   name,
@@ -30,5 +32,7 @@ export {
   theme,
   enableThumbs,
   resizePreview,
-  enableExec
+  enableExec,
+  commitSHA,
+  gitURL
 }

--- a/http/static.go
+++ b/http/static.go
@@ -41,6 +41,8 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, fSys 
 		"EnableThumbs":    d.server.EnableThumbnails,
 		"ResizePreview":   d.server.ResizePreview,
 		"EnableExec":      d.server.EnableExec,
+		"CommitSHA":       version.CommitSHA,
+		"GitURL":          version.GitURL,
 	}
 
 	if d.settings.Branding.Files != "" {

--- a/version/version.go
+++ b/version/version.go
@@ -5,4 +5,6 @@ var (
 	Version = "(untracked)"
 	// CommitSHA is the commmit sha.
 	CommitSHA = "(unknown)"
+	// GitURL is the url of the remote
+	GitURL = "(unavailable)"
 )


### PR DESCRIPTION
**Description**
Add commit SHA to filebrowser sidebar, links to the appropriate repository commit. This makes it easier to see which commit the build came from.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ ] AVOID breaking the continuous integration build.

**Further comments**
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
